### PR TITLE
Expose capabilities list as a host function

### DIFF
--- a/examples/add_remove.rs
+++ b/examples/add_remove.rs
@@ -20,15 +20,33 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         generate_port_config(8082),
     )?;
 
-    // Need to wait until the HTTP server finishes starting before we 
+    println!("Actors (before removal):");
+    for (id, _claims) in host::actors() {
+        println!(" - {}", id);
+    }
+    println!("Capabilities:");
+    for cap in host::capabilities() {
+        println!("{:?}", cap);
+    }
+
+    // Need to wait until the HTTP server finishes starting before we
     // should try and kill it.
-    std::thread::sleep(std::time::Duration::from_millis(800));
+    println!("Sleeping 1s...");
+    std::thread::sleep(std::time::Duration::from_millis(1000));
 
     // This will terminate the actor and free up the HTTP port
     host::remove_actor("MB4OLDIC3TCZ4Q4TGGOVAZC43VXFE2JQVRAXQMQFXUCREOOFEKOKZTY2")?;
 
+    println!("Sleeping 2s...");
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    println!("Actors (after removal of second echo):");
+    for (id, _claims) in host::actors() {
+        println!(" - {}", id);
+    }
+
     // ..
-    // at this point, curling on port 8081 should fail w/connection refused 
+    // at this point, curling on port 8081 should fail w/connection refused
     // while curling on port 8082 should work just fine
 
     std::thread::park();

--- a/examples/replace.rs
+++ b/examples/replace.rs
@@ -30,7 +30,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     io::stdin().read_line(&mut input)?;
     // Note that we don't supply the public key of the one to replace, it
     // comes straight from the Actor being replaced. You cannot replace actors
-    // that do not have the same public key as a security measure against 
+    // that do not have the same public key as a security measure against
     // malicious code
     host::replace_actor(Actor::from_file(
         "./examples/.assets/kvcounter_tweaked.wasm",

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -66,6 +66,11 @@ pub(crate) fn store_claims(claims: Claims) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn remove_claims(subject: &str) -> Result<()> {
+    CLAIMS.write().unwrap().remove(subject);
+    Ok(())
+}
+
 pub(crate) fn map_claims(id: u64, public_key: &str) {
     CLAIMS_MAP
         .write()

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -18,6 +18,13 @@ use libloading::Symbol;
 use std::ffi::OsStr;
 use wascc_codec::capabilities::CapabilityProvider;
 
+#[derive(Debug, Clone)]
+pub struct CapabilitySummary {
+    pub name: String,
+    pub id: String,
+    pub portable: bool,
+}
+
 /// Represents a native capability provider compiled as a shared object library.
 /// These plugins are OS-specific, so they will be `.so` files on Linux, `.dylib`
 /// files on macOS, etc.
@@ -56,5 +63,13 @@ impl NativeCapability {
             plugin,
             library,
         })
+    }
+
+    pub fn id(&self) -> String {
+        self.capid.clone()
+    }
+
+    pub fn name(&self) -> String {
+        self.plugin.name().to_string()
     }
 }


### PR DESCRIPTION
* Add a `capabilities()` function to go along with the existing `actors()` function
* Expose the `id()` and `name()` functions on the `NativeCapability` type
* Fix a dupe-checking bug that didn't check for a duplicate capability ID early enough