### PR TITLE
Implement Gantry client configuration, and actor downloads from Gantry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ prost = "0.6.1"
 log = "0.4.8"
 env_logger = "0.7.1"
 lazy_static = "1.4.0"
+gantryclient = { path = "../gantry/client/gantryclient"}
 rand = "0.7.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ prost = "0.6.1"
 log = "0.4.8"
 env_logger = "0.7.1"
 lazy_static = "1.4.0"
-gantryclient = { path = "../gantry/client/gantryclient"}
+gantryclient = "0.0.1"
 rand = "0.7.3"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -45,16 +45,19 @@ impl Actor {
     }
 
     /// Create an actor from the Gantry registry
-    pub fn from_gantry(actor: &str, client: &Client) -> Result<Actor> {
+    pub fn from_gantry(actor: &str) -> Result<Actor> {
         let (s, r) = unbounded();
-        let _ack = client.download_actor(actor, move |chunk| {
-            let mut bytevec: Vec<u8> = Vec::new();
-            bytevec.extend_from_slice(&chunk.chunk_bytes);
-            if chunk.sequence_no == chunk.total_chunks {
-                s.send(bytevec).unwrap();
-            }
-            Ok(())
-        });
+        let _ack = crate::host::GANTRYCLIENT
+            .read()
+            .unwrap()
+            .download_actor(actor, move |chunk| {
+                let mut bytevec: Vec<u8> = Vec::new();
+                bytevec.extend_from_slice(&chunk.chunk_bytes);
+                if chunk.sequence_no == chunk.total_chunks {
+                    s.send(bytevec).unwrap();
+                }
+                Ok(())
+            });
         let downloaded_bytes = r.recv().unwrap();
         Actor::from_bytes(downloaded_bytes)
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -15,7 +15,6 @@
 use crate::authz;
 use crate::Result;
 use crossbeam_channel::unbounded;
-use gantryclient::*;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -14,6 +14,8 @@
 
 use crate::authz;
 use crate::Result;
+use crossbeam_channel::unbounded;
+use gantryclient::*;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
@@ -40,6 +42,21 @@ impl Actor {
         file.read_to_end(&mut buf)?;
 
         Actor::from_bytes(buf)
+    }
+
+    /// Create an actor from the Gantry registry
+    pub fn from_gantry(actor: &str, client: &Client) -> Result<Actor> {
+        let (s, r) = unbounded();
+        let _ack = client.download_actor(actor, move |chunk| {
+            let mut bytevec: Vec<u8> = Vec::new();
+            bytevec.extend_from_slice(&chunk.chunk_bytes);
+            if chunk.sequence_no == chunk.total_chunks {
+                s.send(bytevec).unwrap();
+            }
+            Ok(())
+        });
+        let downloaded_bytes = r.recv().unwrap();
+        Actor::from_bytes(downloaded_bytes)
     }
 
     /// Obtain the actor's public key. This is globally unique identifier


### PR DESCRIPTION
Fixes #11 

Gives the host the ability to configure a GantryClient using NATS urls, their user jwt and seed key. Also provides a `from_gantry` function to download an actor from Gantry using the configured Gantry client within the host.

Note: This PR uses relative paths for the gantryclient crate, and it has not been tested locally. I wanted to publish it for code review initially before spending time getting gantry setup locally.