### PR TITLE
Remove quicli from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.11"
 serde_json = "1.0"
 
-quicli = "0.4"
 structopt = "0.3.11"


### PR DESCRIPTION
`quicli` is not being used and as it's a fairly heavy dependency there's really no reason to keep it. 