### PR TITLE
Add functions to expand environment variables in YAML and JSON manifest files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-host"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"
@@ -37,12 +37,13 @@ gantryclient = { version = "0.0.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8.11", optional = true }
 serde_json = { version = "1.0", optional = true }
+envmnt = { version = "0.8.1", optional = true }
 
 structopt = { version = "0.3.11", optional = true }
 
 [features]
 default = []
-manifest = ["serde", "serde_yaml", "serde_json"]
+manifest = ["serde", "serde_yaml", "serde_json", "envmnt"]
 bin = ["structopt"]
 gantry = ["gantryclient"]
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -9,7 +9,7 @@ extern crate log;
 #[derive(Debug, StructOpt, Clone)]
 #[structopt(
     global_settings(&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]),
-    name = "wascc-host", 
+    name = "wascc-host",
     about = "A general-purpose waSCC runtime host")]
 struct Cli {
     #[structopt(flatten)]
@@ -21,6 +21,9 @@ struct CliCommand {
     /// Path to the host manifest
     #[structopt(short = "m", long = "manifest", parse(from_os_str))]
     manifest_path: PathBuf,
+    /// Whether to expand environment variables in the host manifest
+    #[structopt(short = "e", long = "expand-env")]
+    expand_env: bool,
 }
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
@@ -28,7 +31,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let cmd = args.command;
     env_logger::init();
 
-    let manifest = HostManifest::from_yaml(cmd.manifest_path)?;
+    let manifest = HostManifest::from_yaml(cmd.manifest_path, cmd.expand_env)?;
     info!(
         "waSCC Host Manifest loaded, CWD: {:?}",
         std::env::current_dir()?


### PR DESCRIPTION
Closes https://github.com/wascc/wascc-host/issues/19.
Please feel free to suggest alternative function names.

Unit tests:

```console
$ cargo test --features manifest manifest
    Finished test [unoptimized + debuginfo] target(s) in 0.15s
     Running target/debug/deps/wascc_host-d6ab5707feff823e

running 2 tests
test manifest::test::env_expansion ... ok
test manifest::test::round_trip ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
```