### PR TITLE
Safe actor removal and capability invocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-host"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"
@@ -20,7 +20,7 @@ features = [ "gantry", "manifest" ]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-libloading = "0.6.0"
+libloading = "0.6.1"
 crossbeam-channel = "0.4.2"
 crossbeam = "0.7.3"
 crossbeam-utils = "^0.7.0"
@@ -39,7 +39,7 @@ gantryclient = { version = "0.0.4", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8.11", optional = true }
 serde_json = { version = "1.0", optional = true }
-envmnt = { version = "0.8.1", optional = true }
+envmnt = { version = "0.8.2", optional = true }
 
 structopt = { version = "0.3.13", optional = true }
 

--- a/examples/assemblyscript.rs
+++ b/examples/assemblyscript.rs
@@ -10,7 +10,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         None,
     )?)?;
     host.add_native_capability(NativeCapability::from_file(
-        "./examples/.assets/libredis_provider.so",
+        "./examples/.assets/libwascc_redis.so",
         None,
     )?)?;
 

--- a/examples/kvcounter.rs
+++ b/examples/kvcounter.rs
@@ -10,7 +10,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         None,
     )?)?;
     host.add_native_capability(NativeCapability::from_file(
-        "./examples/.assets/libredis_provider.so",
+        "./examples/.assets/libwascc_redis.so",
         None,
     )?)?;
 

--- a/examples/kvcounter_manifest.rs
+++ b/examples/kvcounter_manifest.rs
@@ -3,12 +3,15 @@
 // features enabled, you can do that as follows from the root wascc-host directory:
 // cargo run --example kvcounter_manfifest --all-features
 
-use wascc_host::{WasccHost, HostManifest};
+use wascc_host::{HostManifest, WasccHost};
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let host = WasccHost::new();
-    host.apply_manifest(HostManifest::from_yaml("./examples/sample_manifest.yaml", false)?)?;
+    host.apply_manifest(HostManifest::from_yaml(
+        "./examples/sample_manifest.yaml",
+        false,
+    )?)?;
 
     std::thread::park();
     Ok(())

--- a/examples/logger.rs
+++ b/examples/logger.rs
@@ -4,7 +4,7 @@ use wascc_host::{Actor, NativeCapability, WasccHost};
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let host = WasccHost::new();
-    host.add_actor(Actor::from_file("./examples/.assets/logger.wasm")?)?;    
+    host.add_actor(Actor::from_file("./examples/.assets/logger.wasm")?)?;
     host.add_native_capability(NativeCapability::from_file(
         "./examples/.assets/libwascc_httpsrv.so",
         None,
@@ -20,7 +20,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         None,
         generate_port_config(8081),
     )?;
-    
+
     std::thread::park();
 
     Ok(())

--- a/examples/named_bindings.rs
+++ b/examples/named_bindings.rs
@@ -22,11 +22,11 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // we could use Redis and an in-memory store or Redis and Cassandra or
     // Cassandra and etcd and so on
     host.add_native_capability(NativeCapability::from_file(
-        "./examples/.assets/libredis_provider.so",
+        "./examples/.assets/libwascc_redis.so",
         Some("source1".to_string()),
     )?)?;
     host.add_native_capability(NativeCapability::from_file(
-        "./examples/.assets/libredis_provider.so",
+        "./examples/.assets/libwascc_redis.so",
         Some("source2".to_string()),
     )?)?;
 

--- a/examples/sample_manifest.yaml
+++ b/examples/sample_manifest.yaml
@@ -3,7 +3,7 @@
 actors:
     - ./examples/.assets/kvcounter.wasm
 capabilities:
-    - path: ./examples/.assets/libredis_provider.so      
+    - path: ./examples/.assets/libwascc_redis.so      
     - path: ./examples/.assets/libwascc_httpsrv.so
 bindings:
     - actor: "MASCXFM4R6X63UD5MSCDZYCJNPBVSIU6RKMXUPXRKAOSBQ6UY3VT3NPZ"

--- a/examples/start_stop.rs
+++ b/examples/start_stop.rs
@@ -6,6 +6,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let host = WasccHost::new();
     host.add_actor(Actor::from_file("./examples/.assets/kvcounter.wasm")?)?;
+    host.add_actor(Actor::from_file("./examples/.assets/echo.wasm")?)?; // This actor doesn't get removed
     host.add_native_capability(NativeCapability::from_file(
         "./examples/.assets/libwascc_httpsrv.so",
         None,
@@ -14,6 +15,13 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         "./examples/.assets/libwascc_redis.so",
         None,
     )?)?;
+
+    host.bind_actor(
+        "MB4OLDIC3TCZ4Q4TGGOVAZC43VXFE2JQVRAXQMQFXUCREOOFEKOKZTY2",
+        "wascc:http_server",
+        None,
+        generate_port_config(8082),
+    )?;
 
     host.bind_actor(
         "MASCXFM4R6X63UD5MSCDZYCJNPBVSIU6RKMXUPXRKAOSBQ6UY3VT3NPZ",
@@ -25,37 +33,18 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         "MASCXFM4R6X63UD5MSCDZYCJNPBVSIU6RKMXUPXRKAOSBQ6UY3VT3NPZ",
         "wascc:http_server",
         None,
-        http_config(),
+        generate_port_config(8081),
     )?;
 
     println!(
-        "**> curl localhost:8081/counter1 to test, then press ENTER to replace with a new version"
+        "**> curl localhost:8081/counter1 to test, then press ENTER to remove the actor from the host"
     );
     let mut input = String::new();
     io::stdin().read_line(&mut input)?;
-    // Note that we don't supply the public key of the one to replace, it
-    // comes straight from the Actor being replaced. You cannot replace actors
-    // that do not have the same public key as a security measure against
-    // malicious code
-    host.replace_actor(Actor::from_file(
-        "./examples/.assets/kvcounter_tweaked.wasm",
-    )?)?;
-    println!("**> KV counter replaced, issue query to see the new module running.");
 
-    println!("**> Press ENTER to remove the key-value provider");
+    host.remove_actor("MASCXFM4R6X63UD5MSCDZYCJNPBVSIU6RKMXUPXRKAOSBQ6UY3VT3NPZ")?;
+    println!("Actor removed. Echo server should still be working. Press ENTER to finish");
     io::stdin().read_line(&mut input)?;
-    host.remove_native_capability("wascc:keyvalue", None)?;
-
-    println!("**> Press ENTER to add an in-memory key-value provider");
-    io::stdin().read_line(&mut input)?;
-    host.add_native_capability(NativeCapability::from_file(
-        "./examples/.assets/libkeyvalue.so",
-        None,
-    )?)?;
-
-    println!("**> Now your counter should have started over.");
-
-    std::thread::park();
 
     Ok(())
 }
@@ -67,9 +56,9 @@ fn redis_config() -> HashMap<String, String> {
     hm
 }
 
-fn http_config() -> HashMap<String, String> {
+fn generate_port_config(port: u16) -> HashMap<String, String> {
     let mut hm = HashMap::new();
-    hm.insert("PORT".to_string(), "8081".to_string());
+    hm.insert("PORT".to_string(), port.to_string());
 
     hm
 }

--- a/examples/subscriber.rs
+++ b/examples/subscriber.rs
@@ -7,7 +7,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     host.add_actor(Actor::from_file("./examples/.assets/subscriber.wasm")?)?;
     host.add_actor(Actor::from_file("./examples/.assets/subscriber2.wasm")?)?;
     host.add_native_capability(NativeCapability::from_file(
-        "./examples/.assets/libnats_provider.so",
+        "./examples/.assets/libwascc_nats.so",
         None,
     )?)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,7 +56,7 @@ impl StdError for Error {
             ErrorKind::Authorization(_) => "Module authorization failure",
             ErrorKind::CapabilityProvider(_) => "Capability provider failure",
             ErrorKind::MiscHost(_) => "waSCC Host error",
-            ErrorKind::Plugin(_) => "Plugin error"
+            ErrorKind::Plugin(_) => "Plugin error",
         }
     }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -43,7 +43,11 @@ pub(crate) fn invoke_capability(inv: Invocation) -> Result<InvocationResponse> {
 
     let lock = crate::plugins::PLUGMAN.read().unwrap();
 
-    let r = lock.call(&inv).unwrap();
+    let r = match lock.call(&inv) {
+        Ok(r) => r,
+        Err(e) => InvocationResponse::error(&format!("Failed to invoke capability: {}", e)),
+    };
+
     match run_capability_post_invoke(r.clone(), &MIDDLEWARES.read().unwrap()) {
         Ok(r) => Ok(r),
         Err(e) => {


### PR DESCRIPTION
a) An error returning from a capability invocation could panic the middleware chain and thus destabilize the waSCC host. This is fixed.

b) We now only send the `OP_REMOVE_ACTOR` message to capabilities that had originally been bound to the actor in the first place.

@thomastaylor312