### PR TITLE
Added `actors_by_tag` that gets actors based on their tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,4 +490,18 @@ impl WasccHost {
         let lock = self.caps.read().unwrap();
         lock.clone()
     }
+
+    pub fn actors_by_tag(&self, tags: &[&str]) -> Vec<String> {
+        let mut actors = vec![];
+
+        for (actor, claims) in self.claims.read().unwrap().iter() {
+            if let Some(actor_tags) = claims.metadata.as_ref().and_then(|m| m.tags.as_ref()) {
+                if tags.iter().all(|&t| actor_tags.contains(&t.to_string())) {
+                    actors.push(actor.to_string())
+                }
+            }
+        }
+
+        actors
+    }
 }


### PR DESCRIPTION
Fixes #34 

Manually tested by adding tags to `echo.wasm` and `echo2.wasm`:

- `wascap sign ../wascc-host/examples/.assets/echo.wasm ../wascc-host/examples/.assets/echo.wasm --issuer ../wascc-host/examples/.assets/act.nk --subject ../wascc-host/examples/.assets/mod1.nk -s --name "Echo Actor" --tag example echo`
- `wascap sign ../wascc-host/examples/.assets/echo2.wasm ../wascc-host/examples/.assets/echo2.wasm --issuer ../wascc-host/examples/.assets/act.nk --subject ../wascc-host/examples/.assets/mod2.nk -s --name "Echo Actor 2" --tag example echo2`

Ran a locally modified version of the `add_remove` example that listed actors by tag and verified the output.

Signed-off-by: andrisak <andrisak@gmail.com>