### PR TITLE
Closes #54 - graceful shutdown

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,14 +37,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2       
-      - name: Run tests Gantry+Manifest
-        run: cargo test --verbose --features "manifest gantry bin"      
+      - name: Run tests (Everything but Lattice)
+        run: cargo test --verbose --features "manifest gantry bin prometheus_middleware"      
       - name: Run tests (manifest only)
         run: cargo test --verbose --features "manifest"      
       - name: Run tests (gantry only)
         run: cargo test --verbose --features "gantry"      
       - name: Run tests (lattice mode)
-        run: cargo test --features "lattice manifest" --test integration -- --test-threads=1
+        run: cargo test --features "lattice bin manifest gantry" --test integration -- --test-threads=1
         env:
           LATTICE_HOST: 0.0.0.0
           LATTICE_RPC_TIMEOUT_MILLIS: 100

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ features = [ "gantry", "manifest", "lattice" ]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-libloading = "0.6.2"
+libloading = "0.6.3"
 crossbeam-channel = "0.4.3"
 crossbeam = "0.7.3"
 crossbeam-utils = "^0.7.0"
@@ -49,8 +49,10 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8.13", optional = true }
 serde_json = { version = "1.0", optional = true }
 envmnt = { version = "0.8.4", optional = true }
-structopt = { version = "0.3.16", optional = true }
+structopt = { version = "0.3.17", optional = true }
 latticeclient = { version = "0.2.1" , optional = true}
+ctrlc = { version = "3.1.6", features = ["termination"], optional = true}
+
 [dev-dependencies]
 reqwest = { version = "0.10", features = ["blocking"] }
 mockito = "0.27"
@@ -61,7 +63,7 @@ nats = "0.7.3"
 [features]
 default = []
 manifest = ["serde", "serde_yaml", "serde_json", "envmnt"]
-bin = ["structopt"]
+bin = ["structopt", "ctrlc"]
 gantry = ["gantryclient"]
 prometheus_middleware = ["prometheus", "hyper", "tokio"]
 lattice = ["nats", "serde", "latticeclient", "serde_json"]

--- a/src/bus/lattice.rs
+++ b/src/bus/lattice.rs
@@ -136,7 +136,8 @@ impl DistributedBus {
         };
         let lock = self.nc.read().unwrap();
         if let Some(ref nc) = lock.as_ref() {
-            let _ = nc.publish(&*self.event_subject(), &payload);
+            nc.publish(&*self.event_subject(), &payload)?;
+            nc.flush()?;
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,9 +165,9 @@ impl HostBuilder {
     /// Sets the lattice namespace for this host. A lattice namespace is a unit of multi-tenant
     /// isolation on a network
     #[cfg(feature = "lattice")]
-    pub fn with_lattice_namespace(self, ns: String) -> HostBuilder {
+    pub fn with_lattice_namespace(self, ns: &str) -> HostBuilder {
         HostBuilder {
-            ns: Some(ns),
+            ns: Some(ns.to_string()),
             ..self
         }
     }

--- a/tests/lattice.rs
+++ b/tests/lattice.rs
@@ -3,15 +3,18 @@ use std::error::Error;
 
 pub(crate) fn lattice_single_host() -> Result<(), Box<dyn Error>> {
     use std::time::Duration;
-    use wascc_host::Host;
+    use wascc_host::{Host, HostBuilder};
 
-    let host = Host::new();
+    let host = HostBuilder::new()
+        .with_lattice_namespace("singlehost")
+        .build();
+
     host.set_label("integration", "test");
     host.set_label("hostcore.arch", "FOOBAR"); // this should be ignored
     let delay = Duration::from_millis(500);
     std::thread::sleep(delay);
 
-    let lc = Client::new("127.0.0.1", None, delay, None);
+    let lc = Client::new("127.0.0.1", None, delay, Some("singlehost".to_string()));
     let hosts = lc.get_hosts()?;
     assert_eq!(hosts.len(), 1);
     assert_eq!(hosts[0].labels["hostcore.os"], std::env::consts::OS);
@@ -27,14 +30,14 @@ pub(crate) fn lattice_single_host() -> Result<(), Box<dyn Error>> {
 }
 
 pub(crate) fn lattice_isolation() -> Result<(), Box<dyn Error>> {
-    use ::std::time::Duration;
+    use std::time::Duration;
     use wascc_host::{Host, HostBuilder};
     let host1 = HostBuilder::new()
-        .with_lattice_namespace("system.1".to_string())
+        .with_lattice_namespace("system.1")
         .with_label("testval", "1")
         .build();
     let host2 = HostBuilder::new()
-        .with_lattice_namespace("system.2".to_string())
+        .with_lattice_namespace("system.2")
         .with_label("testval", "2")
         .build();
 


### PR DESCRIPTION
Host binary will now perform a graceful shutdown (including emitting "host stopped" event) when a SIGINT or SIGTERM is trapped.