### PR TITLE
Support for lattice-based control plane actor management

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,13 +38,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2       
       - name: Run tests (Everything but Lattice)
-        run: cargo test --verbose --features "manifest gantry bin prometheus_middleware"      
+        run: cargo test --verbose --features "manifest bin prometheus_middleware"      
       - name: Run tests (manifest only)
-        run: cargo test --verbose --features "manifest"      
-      - name: Run tests (gantry only)
-        run: cargo test --verbose --features "gantry"      
+        run: cargo test --verbose --features "manifest"            
       - name: Run tests (lattice mode)
-        run: cargo test --features "lattice bin manifest gantry" --test integration -- --test-threads=1
+        run: cargo test --features "lattice bin manifest" --test integration -- --test-threads=1
         env:
           LATTICE_HOST: 0.0.0.0
           LATTICE_RPC_TIMEOUT_MILLIS: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_
 
-## [0.12.0] - ?? AUG ??
+## [0.13.0] - 2020 SEP 30
+
+This version corresponds to the project milestone [0.13](https://github.com/wascc/wascc-host/milestone/2)
+
+### Added
+
+* _Lattice Control Plane Protocol_ - A new protocol is now supported on the lattice to allow for "auctions" to take place to gather a list of hosts willing to launch a given actor. An auction request is sent out with a set of constraints, any host that can satisfy those contraints responds affirmatively to the auction, and then the conductor of the auction chooses from among the responding hosts and sends a command to that specific host telling it to launch the actor in question. Launching that actor is then done by downloading the actor's bytes from a [Gantry](https://github.com/wascc/gantry) server and running it. You can specify a set of key/value pairs that define constraints that are matched against host labels to definite affinity-style scheduling rules.
+* _Sim Gantry_ - The gantry repo now has a "sim gantry" binary that developers can use to instantly start a Gantry host atop an arbitrary directory that contains signed actor modules.
+
+### Changed
+
+* You can no longer invoke `configure_gantry` on a running host. The gantry client can only be supplied by the host builder now, further improving the runtime security and reliability of the host.
+* The `gantry` feature has been merged with the `lattice` feature. Gantry (client) support is no longer an isolated opt-in feature because both require the NATS connection in order to function and it didn't make sense to communicate with Gantry while not having the ability to connect to a lattice.
+* Renamed `from_bytes` on the `Actor` struct to `from_slice`, and it now takes a `&[u8]` parameter instead of an owned vector.
+* Loading an actor from gantry via the host API call now requires a revision number (0 indicates pull the latest)
+* The Gantry client API to download an actor no longer requires a callback, it simply returns a vector of bytes.
+
+### Removed
+
+Nothing
+
+## [0.12.0] - 2020 AUG 30
 
 This version corresponds to the project milestone 0.12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ serde_yaml = { version = "0.8.13", optional = true }
 serde_json = { version = "1.0", optional = true }
 envmnt = { version = "0.8.4", optional = true }
 structopt = { version = "0.3.17", optional = true }
-#latticeclient = { version = "0.2.1" , optional = true}
-latticeclient = { path = "../lattice-client", optional = true }
+latticeclient = { version = "0.3.0" , optional = true}
 ctrlc = { version = "3.1.6", features = ["termination"], optional = true}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-host"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"
@@ -19,7 +19,7 @@ name = "integration"
 path = "tests/lib.rs"
 
 [package.metadata.docs.rs]
-features = [ "gantry", "manifest", "lattice" ]
+features = [ "manifest", "lattice" ]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -40,17 +40,18 @@ rand = "0.7.3"
 env_logger = "0.7.1"
 ring = "0.16.15"
 data-encoding = "2.3.0"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 # Opt-in dependencies chosen by feature flags
-uuid = { version = "0.8", features = ["serde", "v4"] }
-gantryclient = { version = "0.0.7", optional = true }
+gantryclient = { version = "0.0.9", optional = true }
 nats = { version = "0.7.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8.13", optional = true }
 serde_json = { version = "1.0", optional = true }
 envmnt = { version = "0.8.4", optional = true }
 structopt = { version = "0.3.17", optional = true }
-latticeclient = { version = "0.2.1" , optional = true}
+#latticeclient = { version = "0.2.1" , optional = true}
+latticeclient = { path = "../lattice-client", optional = true }
 ctrlc = { version = "3.1.6", features = ["termination"], optional = true}
 
 [dev-dependencies]
@@ -64,9 +65,8 @@ nats = "0.7.3"
 default = []
 manifest = ["serde", "serde_yaml", "serde_json", "envmnt"]
 bin = ["structopt", "ctrlc"]
-gantry = ["gantryclient"]
 prometheus_middleware = ["prometheus", "hyper", "tokio"]
-lattice = ["nats", "serde", "latticeclient", "serde_json"]
+lattice = ["nats", "serde", "latticeclient", "serde_json", "gantryclient"]
 
 [[example]]
 name = "kvcounter_manifest"

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -16,9 +16,12 @@ pub struct Actor {
 impl Actor {
     /// Create an actor from the bytes of a signed WebAssembly module. Attempting to load
     /// an unsigned module, or a module signed improperly, will result in an error
-    pub fn from_bytes(buf: Vec<u8>) -> Result<Actor> {
+    pub fn from_slice(buf: &[u8]) -> Result<Actor> {
         let token = authz::extract_claims(&buf)?;
-        Ok(Actor { token, bytes: buf })
+        Ok(Actor {
+            token,
+            bytes: buf.to_vec(),
+        })
     }
 
     /// Create an actor from a signed WebAssembly (`.wasm`) file
@@ -27,7 +30,7 @@ impl Actor {
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
 
-        Actor::from_bytes(buf)
+        Actor::from_slice(&buf)
     }
 
     /// Obtain the actor's public key (The `sub` field of a JWT). This can be treated as a globally unique identifier

--- a/src/authz.rs
+++ b/src/authz.rs
@@ -84,7 +84,7 @@ pub(crate) fn extract_claims(buf: &[u8]) -> Result<wascap::jwt::Token<wascap::jw
             let claims = token.claims.clone();
             let caps = claims.metadata.as_ref().unwrap().caps.clone();
             info!(
-                "Discovered capability attestations for actor {}: {}",
+                "Actor claims loaded for {} - {}",
                 &claims.subject,
                 caps.unwrap_or(vec![]).join(",")
             );

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -50,7 +50,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     } else {
         info!("Starting without manifest");
         #[cfg(not(feature = "lattice"))]
-        warn!("Started without manifest and without lattice. This host cannot launch actors or providers.");
+        {
+            error!("Started without manifest and without lattice. This host cannot launch actors or providers. Shutting down.");
+            return Err("Started without manifest or lattice - unusable host".into());
+        }
     }
 
     let (term_s, term_r) = std::sync::mpsc::channel();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
+use std::time::Duration;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
-use wascc_host::{Host, HostManifest};
+use wascc_host::{Host, HostBuilder, HostManifest};
 
 #[macro_use]
 extern crate log;
@@ -20,7 +21,7 @@ struct Cli {
 struct CliCommand {
     /// Path to the host manifest
     #[structopt(short = "m", long = "manifest", parse(from_os_str))]
-    manifest_path: PathBuf,
+    manifest_path: Option<PathBuf>,
     /// Whether to expand environment variables in the host manifest
     #[structopt(short = "e", long = "expand-env")]
     expand_env: bool,
@@ -36,11 +37,21 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     .format_module_path(false)
     .try_init();
 
-    let host = Host::new();
+    let mut builder = HostBuilder::new();
+    #[cfg(feature = "lattice")]
+    let builder = builder.with_gantryclient(get_gantry_client());
 
-    let manifest = HostManifest::from_path(cmd.manifest_path, cmd.expand_env)?;
-    host.apply_manifest(manifest)?;
-    info!("Processed and applied host manifest");
+    let host = builder.build();
+
+    if let Some(ref mp) = cmd.manifest_path {
+        let manifest = HostManifest::from_path(mp, cmd.expand_env)?;
+        host.apply_manifest(manifest)?;
+        info!("Processed and applied host manifest");
+    } else {
+        info!("Starting without manifest");
+        #[cfg(not(feature = "lattice"))]
+        warn!("Started without manifest and without lattice. This host cannot launch actors or providers.");
+    }
 
     let (term_s, term_r) = std::sync::mpsc::channel();
 
@@ -64,3 +75,49 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     );
     Ok(())
 }
+
+#[cfg(feature = "lattice")]
+fn get_gantry_client() -> gantryclient::Client {
+    let host = get_env(LATTICE_HOST_KEY, DEFAULT_LATTICE_HOST);
+    let creds = get_credsfile();
+    let timeout = get_timeout();
+
+    info!("Gantry client created.");
+    gantryclient::Client::new(&host, creds.map(|c| c.into()), timeout)
+}
+
+fn get_credsfile() -> Option<String> {
+    std::env::var(LATTICE_CREDSFILE_KEY).ok()
+}
+
+fn get_env(var: &str, default: &str) -> String {
+    match std::env::var(var) {
+        Ok(val) => {
+            if val.is_empty() {
+                default.to_string()
+            } else {
+                val.to_string()
+            }
+        }
+        Err(_) => default.to_string(),
+    }
+}
+
+fn get_timeout() -> Duration {
+    match std::env::var(LATTICE_RPC_TIMEOUT_KEY) {
+        Ok(val) => {
+            if val.is_empty() {
+                Duration::from_millis(DEFAULT_LATTICE_RPC_TIMEOUT_MILLIS)
+            } else {
+                Duration::from_millis(val.parse().unwrap_or(DEFAULT_LATTICE_RPC_TIMEOUT_MILLIS))
+            }
+        }
+        Err(_) => Duration::from_millis(DEFAULT_LATTICE_RPC_TIMEOUT_MILLIS),
+    }
+}
+
+const LATTICE_HOST_KEY: &str = "LATTICE_HOST"; // env var name
+const DEFAULT_LATTICE_HOST: &str = "127.0.0.1"; // default mode is anonymous via loopback
+const LATTICE_RPC_TIMEOUT_KEY: &str = "LATTICE_RPC_TIMEOUT_MILLIS";
+const DEFAULT_LATTICE_RPC_TIMEOUT_MILLIS: u64 = 600;
+const LATTICE_CREDSFILE_KEY: &str = "LATTICE_CREDS_FILE";

--- a/src/bus/lattice.rs
+++ b/src/bus/lattice.rs
@@ -82,7 +82,7 @@ impl DistributedBus {
             cplane_s,
             authz,
         )
-            .unwrap();
+        .unwrap();
 
         spawn_inventory_handler(
             nc.clone(),
@@ -94,7 +94,7 @@ impl DistributedBus {
             labels,
             ns.clone(),
         )
-            .unwrap();
+        .unwrap();
         DistributedBus {
             nc,
             subs: Arc::new(RwLock::new(HashMap::new())),
@@ -547,8 +547,8 @@ fn handle_invocation(
         error!("Invocation Antiforgery check failure: {}", e);
         let inv_r = InvocationResponse::error(&inv, &format!("Antiforgery check failure: {}", e));
         msg.respond(serialize(inv_r).unwrap()).unwrap();
-        // TODO: when we implement the issue, publish an antiforgery check event on wasmbus.events
-        // TODO: when we implement the issue, add the host origin of the invocation to the global lattice block list
+    // TODO: when we implement the issue, publish an antiforgery check event on wasmbus.events
+    // TODO: when we implement the issue, add the host origin of the invocation to the global lattice block list
     } else {
         sender.send(inv).unwrap();
         let inv_r = receiver.recv().unwrap();

--- a/src/bus/lattice.rs
+++ b/src/bus/lattice.rs
@@ -1,16 +1,27 @@
 use crate::{BindingsList, RouteKey};
 use crate::{Invocation, InvocationResponse, Result};
 use crossbeam::{Receiver, Sender};
-use latticeclient::{BusEvent, CloudEvent};
+use crossbeam_channel as channel;
+use latticeclient::{
+    controlplane::{
+        LaunchAck, LaunchAuctionRequest, LaunchAuctionResponse, LaunchCommand, TerminateCommand,
+        AUCTION_REQ, CPLANE_PREFIX, LAUNCH_ACTOR, TERMINATE_ACTOR,
+    },
+    BusEvent, CloudEvent,
+};
 use nats;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::thread;
 use std::time::{Duration, SystemTime};
+use wapc::prelude::*;
 use wascap::jwt::{Actor, Claims};
 use wascc_codec::{capabilities::CapabilityDescriptor, deserialize, serialize};
 
-const LATTICE_HOST_KEY: &str = "LATTICE_HOST"; // env var name
-const DEFAULT_LATTICE_HOST: &str = "127.0.0.1"; // default mode is anonymous via loopback
+const LATTICE_HOST_KEY: &str = "LATTICE_HOST";
+// env var name
+const DEFAULT_LATTICE_HOST: &str = "127.0.0.1";
+// default mode is anonymous via loopback
 const LATTICE_RPC_TIMEOUT_KEY: &str = "LATTICE_RPC_TIMEOUT_MILLIS";
 const DEFAULT_LATTICE_RPC_TIMEOUT_MILLIS: u64 = 600;
 const LATTICE_CREDSFILE_KEY: &str = "LATTICE_CREDS_FILE";
@@ -20,6 +31,13 @@ const TERM_BACKOFF_DELAY_MS: u64 = 50;
 
 use crate::bus::event_subject;
 use latticeclient::*;
+use nats::Message;
+
+#[derive(Debug, Clone)]
+pub(crate) enum ControlCommand {
+    TerminateActor(TerminateCommand),
+    StartActor(LaunchCommand, Message),
+}
 
 pub(crate) struct DistributedBus {
     nc: Arc<RwLock<Option<nats::Connection>>>,
@@ -27,7 +45,7 @@ pub(crate) struct DistributedBus {
     terminators: Arc<RwLock<HashMap<String, Sender<bool>>>>,
     req_timeout: Duration,
     host_id: String,
-    ns: Option<String>,
+    pub(crate) ns: Option<String>,
 }
 
 impl DistributedBus {
@@ -39,6 +57,8 @@ impl DistributedBus {
         labels: Arc<RwLock<HashMap<String, String>>>,
         terminators: Arc<RwLock<HashMap<String, Sender<bool>>>>,
         ns: Option<String>,
+        cplane_s: Sender<ControlCommand>,
+        authz: Arc<RwLock<Box<dyn crate::authz::Authorizer>>>,
     ) -> Self {
         let nc = Arc::new(RwLock::new(Some(get_connection())));
 
@@ -50,6 +70,20 @@ impl DistributedBus {
                 "default namespace"
             }
         );
+
+        spawn_controlplane_handler(
+            nc.clone(),
+            host_id.clone(),
+            claims.clone(),
+            bindings.clone(),
+            caps.clone(),
+            labels.clone(),
+            ns.clone(),
+            cplane_s,
+            authz,
+        )
+            .unwrap();
+
         spawn_inventory_handler(
             nc.clone(),
             host_id.to_string(),
@@ -60,7 +94,7 @@ impl DistributedBus {
             labels,
             ns.clone(),
         )
-        .unwrap();
+            .unwrap();
         DistributedBus {
             nc,
             subs: Arc::new(RwLock::new(HashMap::new())),
@@ -72,6 +106,17 @@ impl DistributedBus {
     }
 
     pub fn disconnect(&self) {
+        // Terminate the control plane command handler
+        let cpsubject = format!(
+            "{}.{}.{}",
+            super::nsprefix(self.ns.as_ref().map(String::as_str)),
+            latticeclient::controlplane::CPLANE_PREFIX,
+            self.host_id
+        );
+        self.terminators.read().unwrap()[&cpsubject]
+            .send(true)
+            .unwrap();
+
         let mut backoffcount = 0_u8;
         // Wait until everything that can be gracefully shut off has been shut off
         while self.terminators.read().unwrap().len() > 0 && backoffcount < TERM_BACKOFF_MAX_TRIES {
@@ -131,7 +176,7 @@ impl DistributedBus {
             Err(e) => {
                 return Err(crate::errors::new(crate::errors::ErrorKind::Serialization(
                     format!("{}", e),
-                )))
+                )));
             }
         };
         let lock = self.nc.read().unwrap();
@@ -171,6 +216,214 @@ impl DistributedBus {
             calling_actor,
         )
     }
+}
+
+pub(crate) fn controlplane_wildcard_subject(ns: Option<&str>) -> String {
+    format!("{}.{}.>", super::nsprefix(ns), CPLANE_PREFIX) // e.g. wasmbus.control.* or wasmbus.control.Nxxx.*
+}
+
+pub(crate) fn spawn_controlplane(
+    host: &crate::Host,
+    com_r: Receiver<ControlCommand>,
+) -> Result<()> {
+    let wg = crossbeam_utils::sync::WaitGroup::new();
+    let claims = host.claims.clone();
+    let wasi: Option<WasiParams> = None;
+    let actor = true;
+    let binding: Option<String> = None;
+    let bus = host.bus.clone();
+    let mids = host.middlewares.clone();
+    let caps = host.caps.clone();
+    let bindings = host.bindings.clone();
+    let claimsmap = host.claims.clone();
+    let terminators = host.terminators.clone();
+    let hk = host.key.clone();
+    let auth = host.authorizer.clone();
+    let gantry = host.gantry_client.clone();
+
+    let subject = format!(
+        "{}.{}.{}",
+        super::nsprefix(bus.ns.as_ref().map(String::as_str)),
+        latticeclient::controlplane::CPLANE_PREFIX,
+        hk.public_key()
+    );
+    let (term_s, term_r): (Sender<bool>, Receiver<bool>) = channel::unbounded();
+    terminators
+        .write()
+        .unwrap()
+        .insert(subject.to_string(), term_s);
+
+    thread::spawn(move || loop {
+        select! {
+            recv(com_r) -> cmd => {
+                if let Ok(cmd) = cmd {
+                    match cmd {
+                        ControlCommand::StartActor(cmd, msg) => {
+                            // Acknowledge before downloading the bytes. Do not keep consumers waiting for
+                            // our own download process.
+                            if let Err(e) = msg.respond(&serde_json::to_vec(&LaunchAck {
+                                actor_id: cmd.actor_id.to_string(),
+                                host: hk.public_key()
+                            }).unwrap()) {
+                                error!("Failed to send schedule acknowledgement reply: {}", e);
+                            } else {
+                                info!("Acknowledged actor start request.");
+                            }
+                            match fetch_actor(&cmd.actor_id, gantry.clone(), cmd.revision) {
+                                Ok(a) => {
+                                    let wg = crossbeam_utils::sync::WaitGroup::new();
+                                    if crate::authz::enforce_validation(&a.token.jwt).is_err() {
+                                        error!("Attempt to remotely schedule invalid actor.");
+                                        continue;
+                                    }
+                                    if !auth.read().unwrap().can_load(&a.token.claims) {
+                                        error!("Authorization hook denied access to remotely scheduled module.");
+                                        continue;
+                                    }
+
+                                    crate::authz::register_claims(
+                                        claims.clone(),
+                                        &a.token.claims.subject,
+                                        a.token.claims.clone(),
+                                    );
+
+                                    let _ = crate::spawns::spawn_actor(wg, a.token.claims.clone(), a.bytes,
+                                        None, actor, binding.clone(), bus.clone(), mids.clone(),
+                                        caps.clone(), bindings.clone(), claimsmap.clone(), terminators.clone(),
+                                        hk.clone(), auth.clone());
+
+
+                                },
+                                Err(e) => {
+                                    error!("Actor download failed for {}: {}", &cmd.actor_id, e)
+                                }
+                            }
+                        },
+                        ControlCommand::TerminateActor(cmd) => {
+                            let actor_subject = bus.actor_subject(&cmd.actor_id);
+                            terminators.read().unwrap()
+                                [&actor_subject]
+                                .send(true)
+                                .unwrap();
+                        }
+                    }
+                }
+            }
+            recv(term_r) -> _term => {
+                terminators.write().unwrap().remove(&subject);
+                break;
+            }
+        }
+    });
+    Ok(())
+}
+
+fn fetch_actor(
+    actor_id: &str,
+    gantry: Arc<RwLock<Option<gantryclient::Client>>>,
+    revision: u32,
+) -> Result<crate::actor::Actor> {
+    let vec = actor_bytes_from_gantry(actor_id, gantry, revision)?;
+
+    crate::actor::Actor::from_slice(&vec)
+}
+
+pub(crate) fn actor_bytes_from_gantry(
+    actor_id: &str,
+    gantry_client: Arc<RwLock<Option<gantryclient::Client>>>,
+    revision: u32,
+) -> Result<Vec<u8>> {
+    {
+        let lock = gantry_client.read().unwrap();
+        if lock.as_ref().is_none() {
+            return Err(crate::errors::new(crate::errors::ErrorKind::MiscHost(
+                "No gantry client configured".to_string(),
+            )));
+        }
+    }
+    match gantry_client
+        .read()
+        .unwrap()
+        .as_ref()
+        .unwrap()
+        .download_actor(actor_id, revision)
+    {
+        Ok(v) => Ok(v),
+        Err(e) => Err(crate::errors::new(crate::errors::ErrorKind::MiscHost(
+            format!("{}", e),
+        ))),
+    }
+}
+
+fn spawn_controlplane_handler(
+    nc: Arc<RwLock<Option<nats::Connection>>>,
+    host_id: String,
+    claims: Arc<RwLock<HashMap<String, Claims<Actor>>>>,
+    bindings: Arc<RwLock<BindingsList>>,
+    caps: Arc<RwLock<HashMap<RouteKey, CapabilityDescriptor>>>,
+    labels: Arc<RwLock<HashMap<String, String>>>,
+    ns: Option<String>,
+    cplane_s: Sender<ControlCommand>,
+    authz: Arc<RwLock<Box<dyn crate::authz::Authorizer>>>,
+) -> Result<()> {
+    let subject = controlplane_wildcard_subject(ns.as_ref().map(String::as_str));
+    let lbs = labels.clone();
+
+    let _ = nc
+        .read()
+        .unwrap()
+        .as_ref()
+        .unwrap()
+        .subscribe(&subject)?
+        .with_handler(move |msg| {
+            if msg.subject.ends_with(LAUNCH_ACTOR) && msg.subject.contains(&host_id) {
+                // schedule the actor
+                let lc: LaunchCommand = serde_json::from_slice(&msg.data).unwrap();
+                cplane_s.send(ControlCommand::StartActor(lc, msg)).unwrap();
+            } else if msg.subject.ends_with(TERMINATE_ACTOR) && msg.subject.contains(&host_id) {
+                let tc: TerminateCommand = serde_json::from_slice(&msg.data).unwrap();
+                if !claims.read().unwrap().contains_key(&tc.actor_id) {
+                    warn!("Received request to terminate non-existent actor. Ignoring.");
+                } else {
+                    cplane_s.send(ControlCommand::TerminateActor(tc)).unwrap();
+                }
+            } else if msg.subject.ends_with(AUCTION_REQ) {
+                let req: LaunchAuctionRequest = serde_json::from_slice(&msg.data)?;
+                if claims.read().unwrap().contains_key(&req.actor_id) {
+                    trace!("Skipping auction response - actor already running locally.");
+                } else {
+                    // TODO: validate constraint requirements
+                    if !host_satifies_constraints(labels.clone(), &req.constraints) {
+                        trace!("Skipping auction response - host does not satisfy constraints.");
+                    } else {
+                        let ar = LaunchAuctionResponse {
+                            host_id: host_id.to_string(),
+                        };
+                        info!("Responding to actor schedule auction request");
+                        let _ = msg.respond(serde_json::to_vec(&ar).unwrap());
+                    }
+                }
+            }
+            Ok(())
+        });
+    Ok(())
+}
+
+fn host_satifies_constraints(
+    labels: Arc<RwLock<HashMap<String, String>>>,
+    constraints: &HashMap<String, String>,
+) -> bool {
+    for (label, val) in constraints.iter() {
+        match labels.read().unwrap().get_key_value(label) {
+            Some((k, v)) => {
+                if v != val {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
+    true
 }
 
 fn spawn_inventory_handler(
@@ -294,8 +547,8 @@ fn handle_invocation(
         error!("Invocation Antiforgery check failure: {}", e);
         let inv_r = InvocationResponse::error(&inv, &format!("Antiforgery check failure: {}", e));
         msg.respond(serialize(inv_r).unwrap()).unwrap();
-    // TODO: when we implement the issue, publish an antiforgery check event on wasmbus.events
-    // TODO: when we implement the issue, add the host origin of the invocation to the global lattice block list
+        // TODO: when we implement the issue, publish an antiforgery check event on wasmbus.events
+        // TODO: when we implement the issue, add the host origin of the invocation to the global lattice block list
     } else {
         sender.send(inv).unwrap();
         let inv_r = receiver.recv().unwrap();

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -39,8 +39,20 @@ pub(crate) fn new(
     labels: Arc<RwLock<HashMap<String, String>>>,
     terminators: Arc<RwLock<HashMap<String, Sender<bool>>>>,
     ns: Option<String>,
+    cplane_s: Sender<lattice::ControlCommand>,
+    authz: Arc<RwLock<Box<dyn crate::authz::Authorizer>>>,
 ) -> MessageBus {
-    lattice::DistributedBus::new(host_id, claims, caps, bindings, labels, terminators, ns)
+    lattice::DistributedBus::new(
+        host_id,
+        claims,
+        caps,
+        bindings,
+        labels,
+        terminators,
+        ns,
+        cplane_s,
+        authz,
+    )
 }
 
 const LATTICE_NAMESPACE_ENV: &str = "LATTICE_NAMESPACE";
@@ -93,7 +105,7 @@ pub(crate) fn provider_subject_bound_actor(
     )
 }
 
-fn nsprefix(ns: Option<&str>) -> String {
+pub(crate) fn nsprefix(ns: Option<&str>) -> String {
     match ns {
         Some(s) => format!("{}.wasmbus", s),
         None => "wasmbus".to_string(),

--- a/src/spawns.rs
+++ b/src/spawns.rs
@@ -9,6 +9,8 @@ use crate::{
     Invocation, InvocationResponse, Middleware, RouteKey,
 };
 use authz::ClaimsMap;
+#[cfg(feature = "lattice")]
+use bus::lattice::ControlCommand;
 use crossbeam::{Receiver, Sender};
 use crossbeam_channel as channel;
 use crossbeam_utils::sync::WaitGroup;
@@ -121,6 +123,7 @@ pub(crate) fn spawn_actor(
                 host: hostkey.public_key(),
                 actor: claims.subject.to_string(),
             });
+            info!("Actor {} up and running.", &claims.subject);
         }
 
         loop {


### PR DESCRIPTION
This PR adds support for lattice-based control plane activities as they relate to actor management, including:

* Hold a scheduling auction - based on a set of constraints, all hosts within the lattice that believe they are capable of satisfying those constraints will respond affirmatively to said auction
* Direct schedule - tell a host (presumably the winner of an auction) to start an actor
* Direct terminate - tell a host to stop / unload an actor
