### PR TITLE
Initial commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 _The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)_
 
+## [0.14.0] - 2020 OCT 30
+
+This version corresponds to the project milestone [0.14](https://github.com/wascc/wascc-host/milestone/3)
+
+### Added
+
+* Host runtime will now look at the `OCI_REGISTRY_USER` and `OCI_REGISTRY_PASSWORD` environment variables whenever it needs to contact an OCI registry.
+
+### Changed
+
+* All non-local references to capability providers and actors are now assumed to be registry references that can be satisfied by the indicated OCI registry. If basic authentication is required by that registry, then you can supply those credentials via the `OCI_REGISTRY_USER` and `OCI_REGISTRY_PASSWORD` environment variables.
+* The `add_actor_from_gantry` function has been renamed to `add_actor_from_registry`
+* Manifest files will now load either actors (if the actor string exists as a file) or registry-hosted modules (if the actor string is a registry reference)
+
+
 ## [0.13.0] - 2020 SEP 30
 
 This version corresponds to the project milestone [0.13](https://github.com/wascc/wascc-host/milestone/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This version corresponds to the project milestone [0.14](https://github.com/wasc
 ### Added
 
 * Host runtime will now look at the `OCI_REGISTRY_USER` and `OCI_REGISTRY_PASSWORD` environment variables whenever it needs to contact an OCI registry.
+* Added the `add_native_capability_from_registry` to download and load an OS/CPU arch appropriate provider plugin.
 
 ### Changed
 
@@ -19,6 +20,11 @@ This version corresponds to the project milestone [0.14](https://github.com/wasc
 * The `add_actor_from_gantry` function has been renamed to `add_actor_from_registry`
 * Manifest files will now load either actors (if the actor string exists as a file) or registry-hosted modules (if the actor string is a registry reference)
 
+### Caution
+
+The ability to remotely schedule capability providers in this version should be considered unstable, to be 
+stabilized in the 0.15.0 release (the "async rewrite"), which will include a rework of how capability providers
+internally subscribe to the message bus and identify themselves to the host and lattice.
 
 ## [0.13.0] - 2020 SEP 30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ serde_json = { version = "1.0.57", optional = true }
 envmnt = { version = "0.8.4", optional = true }
 structopt = { version = "0.3.17", optional = true }
 #latticeclient = { version="0.3.1" , optional = true}
-latticeclient = { path = "../lattice-client", optional = true}
+#latticeclient = { path = "../lattice-client", optional = true}
+latticeclient = { git = "https://github.com/wascc/lattice-client", optional = true }
 ctrlc = { version = "3.1.6", features = ["termination"], optional = true}
 wasm3-provider = { version = "0.0.1", optional = true}
 wasmtime-provider = { version = "0.0.1" , optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "0.2", features = ["macros"] }
 wapc = { version = "0.10.0" }
 
 wascc-codec = "0.8"
-wascap = "0.5.0"
+wascap = "0.5.1"
 log = "0.4.11"
 rand = "0.7.3"
 env_logger = "0.7.1"
@@ -44,16 +44,18 @@ data-encoding = "2.3.0"
 oci-distribution = "0.4.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 futures = "0.3.6"
+provider-archive = "0.1.0"
 
 
 # Opt-in dependencies chosen by feature flags
-nats = { version = "0.7.3", optional = true }
+nats = { git = "https://github.com/autodidaddict/nats.rs", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8.13", optional = true }
 serde_json = { version = "1.0.57", optional = true }
 envmnt = { version = "0.8.4", optional = true }
 structopt = { version = "0.3.17", optional = true }
-latticeclient = { version="0.3.1" , optional = true}
+#latticeclient = { version="0.3.1" , optional = true}
+latticeclient = { path = "../lattice-client", optional = true}
 ctrlc = { version = "3.1.6", features = ["termination"], optional = true}
 wasm3-provider = { version = "0.0.1", optional = true}
 wasmtime-provider = { version = "0.0.1" , optional = true}
@@ -62,7 +64,7 @@ wasmtime-provider = { version = "0.0.1" , optional = true}
 reqwest = { version = "0.10", features = ["blocking"] }
 mockito = "0.27"
 redis = "0.17.0"
-nats = "0.7.3"
+nats = {  git = "https://github.com/autodidaddict/nats.rs" }
 serde_json = "1.0.57"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-host"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"
@@ -31,9 +31,8 @@ crossbeam = "0.7.3"
 crossbeam-utils = "^0.7.0"
 prometheus = { version = "0.9", features = ["push"], optional = true }
 hyper = { version = "0.13", optional = true }
-tokio = { version = "0.2", features = ["macros"], optional = true }
+tokio = { version = "0.2", features = ["macros"] }
 wapc = { version = "0.10.0" }
-
 
 wascc-codec = "0.8"
 wascap = "0.5.0"
@@ -42,10 +41,12 @@ rand = "0.7.3"
 env_logger = "0.7.1"
 ring = "0.16.15"
 data-encoding = "2.3.0"
+oci-distribution = "0.4.0"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+futures = "0.3.6"
+
 
 # Opt-in dependencies chosen by feature flags
-gantryclient = { version = "0.1.0", optional = true }
 nats = { version = "0.7.3", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_yaml = { version = "0.8.13", optional = true }
@@ -69,8 +70,8 @@ serde_json = "1.0.57"
 default = ["wasmtime"]
 manifest = ["serde", "serde_yaml", "serde_json", "envmnt"]
 bin = ["structopt", "ctrlc"]
-prometheus_middleware = ["prometheus", "hyper", "tokio"]
-lattice = ["nats", "serde", "latticeclient", "serde_json", "gantryclient"]
+prometheus_middleware = ["prometheus", "hyper"]
+lattice = ["nats", "serde", "latticeclient", "serde_json"]
 wasmtime = ["wasmtime-provider"]
 wasm3 = ["wasm3-provider"]
 

--- a/examples/kvcounter_manifest.rs
+++ b/examples/kvcounter_manifest.rs
@@ -1,7 +1,7 @@
 // An example demonstrating loading a manifest
-// For this to run, you'll need both the `manifest` and `gantry`
-// features enabled, you can do that as follows from the root wascc-host directory:
-// cargo run --example kvcounter_manfifest --all-features
+// For this to run, you'll need the `manifest` feature enabled. You can do that as follows from the
+// root wascc-host directory:
+// cargo run --example kvcounter_manfifest --features "manifest"
 
 use wascc_host::{Host, HostManifest};
 

--- a/examples/oci_test.yaml
+++ b/examples/oci_test.yaml
@@ -1,0 +1,20 @@
+# This file demonstrates how to use OCI references in a manifest. This feature is
+# not yet fully stable, and requires that the images referenced below be pushed to 
+# the given registry
+---
+labels:
+    sample: "Key-Value Counter"
+actors:
+    - "wascc.azurecr.io/keyvalue:v1"
+capabilities:
+    - path: wascc.azurecr.io/redis-provider:v1
+    - path: wascc.azurecr.io/httpsrv-provider:v1
+bindings:
+    - actor: "MASCXFM4R6X63UD5MSCDZYCJNPBVSIU6RKMXUPXRKAOSBQ6UY3VT3NPZ"
+      capability: "wascc:keyvalue"
+      values:
+        URL: redis://127.0.0.1:6379
+    - actor: "MASCXFM4R6X63UD5MSCDZYCJNPBVSIU6RKMXUPXRKAOSBQ6UY3VT3NPZ"
+      capability: "wascc:http_server"
+      values:
+        PORT: "8081"

--- a/src/bus/lattice.rs
+++ b/src/bus/lattice.rs
@@ -1,11 +1,11 @@
-use crate::{BindingsList, RouteKey};
+use crate::{BindingsList, NativeCapability, RouteKey};
 use crate::{Invocation, InvocationResponse, Result};
 use crossbeam::{Receiver, Sender};
 use crossbeam_channel as channel;
 use latticeclient::{
     controlplane::{
-        LaunchAck, LaunchAuctionRequest, LaunchAuctionResponse, LaunchCommand, TerminateCommand,
-        AUCTION_REQ, CPLANE_PREFIX, LAUNCH_ACTOR, TERMINATE_ACTOR,
+        LaunchAck, LaunchAuctionRequest, LaunchAuctionResponse, LaunchCommand, ProviderLaunchAck,
+        TerminateCommand, AUCTION_REQ, CPLANE_PREFIX, LAUNCH_ACTOR, TERMINATE_ACTOR,
     },
     BusEvent, CloudEvent,
 };
@@ -29,14 +29,24 @@ const LATTICE_CREDSFILE_KEY: &str = "LATTICE_CREDS_FILE";
 const TERM_BACKOFF_MAX_TRIES: u8 = 3;
 const TERM_BACKOFF_DELAY_MS: u64 = 50;
 
+use crate::inthost::{CORELABEL_ARCH, CORELABEL_OS};
+use latticeclient::controlplane::{
+    LaunchProviderCommand, ProviderAuctionRequest, ProviderAuctionResponse,
+    TerminateProviderCommand, LAUNCH_PROVIDER, PROVIDER_AUCTION_REQ, TERMINATE_PROVIDER,
+};
 use latticeclient::*;
 use nats::Message;
+use std::fs::File;
+use std::path::Path;
 use wapc::WasiParams;
+use wascap::prelude::KeyPair;
 
 #[derive(Debug, Clone)]
 pub(crate) enum ControlCommand {
     TerminateActor(TerminateCommand),
+    TerminateProvider(TerminateProviderCommand),
     StartActor(LaunchCommand, Message),
+    StartProvider(LaunchProviderCommand, Message),
 }
 
 pub(crate) struct DistributedBus {
@@ -326,14 +336,16 @@ pub(crate) fn spawn_controlplane(
     let actor = true;
     let binding: Option<String> = None;
     let bus = host.bus.clone();
+    let plugins = host.plugins.clone();
     let mids = host.middlewares.clone();
     let caps = host.caps.clone();
     let bindings = host.bindings.clone();
     let claimsmap = host.claims.clone();
     let terminators = host.terminators.clone();
-    let hk = host.key.clone();
+    let hk = KeyPair::from_seed(&host.sk).unwrap();
     let auth = host.authorizer.clone();
     let image_map = host.image_map.clone();
+    let labels = host.labels.clone();
 
     let subject = format!(
         "{}.{}.{}",
@@ -348,6 +360,7 @@ pub(crate) fn spawn_controlplane(
         .insert(subject.to_string(), term_s);
 
     thread::spawn(move || loop {
+        let key = KeyPair::from_seed(&hk.seed().unwrap()).unwrap();
         select! {
             recv(com_r) -> cmd => {
                 if let Ok(cmd) = cmd {
@@ -364,7 +377,7 @@ pub(crate) fn spawn_controlplane(
                                 info!("Acknowledged actor start request.");
                             }
                             // As of 0.14.0, the "actor_id" here is actually an OCI registry image reference
-                            match fetch_actor(&cmd.actor_id) {
+                            match crate::inthost::fetch_actor(&cmd.actor_id) {
                                 Ok(a) => {
                                     image_map.write().unwrap().insert(cmd.actor_id.to_string(), a.public_key());
                                     let wg = crossbeam_utils::sync::WaitGroup::new();
@@ -386,7 +399,7 @@ pub(crate) fn spawn_controlplane(
                                     let _ = crate::spawns::spawn_actor(wg, a.token.claims.clone(), a.bytes,
                                         None, actor, binding.clone(), bus.clone(), mids.clone(),
                                         caps.clone(), bindings.clone(), claimsmap.clone(), terminators.clone(),
-                                        hk.clone(), auth.clone(), image_map.clone(), Some(cmd.actor_id.to_string()));
+                                        key, auth.clone(), image_map.clone(), Some(cmd.actor_id.to_string()));
 
 
                                 },
@@ -396,11 +409,60 @@ pub(crate) fn spawn_controlplane(
                             }
                         },
                         ControlCommand::TerminateActor(cmd) => {
-                            let actor_subject = bus.actor_subject(&cmd.actor_id);
+                            let pk = image_map.read().unwrap()[&cmd.actor_id].to_string(); // get PK from the OCI ref
+                            image_map.write().unwrap().remove(&pk);
+                            let actor_subject = bus.actor_subject(&pk);
                             terminators.read().unwrap()
                                 [&actor_subject]
                                 .send(true)
                                 .unwrap();
+                        },
+                        ControlCommand::TerminateProvider(cmd) => {
+                            // TODO: this command will continue to be a no-op until the "async rewrite",
+                            // which should include a re-organization of how providers subscribe to the bus
+                        },
+                        ControlCommand::StartProvider(cmd, msg) => {
+                            if let Err(e) = msg.respond(&serde_json::to_vec(&ProviderLaunchAck {
+                                provider_ref: cmd.provider_ref.to_string(),
+                                host: hk.public_key()
+                            }).unwrap()) {
+                                error!("Failed to send schedule provider acknowledgement reply: {}", e);
+                            } else {
+                                info!("Acknowledged provider start request.");
+                            }
+                            match crate::inthost::fetch_provider(&cmd.provider_ref, &cmd.binding_name, labels.clone()) {
+                                Ok((p, c)) => {
+                                    if caps
+                                       .read()
+                                       .unwrap()
+                                       .contains_key(&RouteKey::new(&cmd.binding_name, &p.id()))
+                                    {
+                                        error!(
+                                          "Capability provider {} cannot be bound to the same name ({}) twice, loading failed.", p.id(), &cmd.binding_name
+                                        );
+                                    }
+                                    caps.write().unwrap().insert(
+                                        RouteKey::new(&cmd.binding_name, &p.descriptor.id),
+                                        p.descriptor().clone(),
+                                    );
+                                    let wg = crossbeam_utils::sync::WaitGroup::new();
+                                    let key = KeyPair::from_seed(&hk.seed().unwrap()).unwrap();
+                                    let _ = crate::spawns::spawn_native_capability(
+                                        p,
+                                        bus.clone(),
+                                        mids.clone(),
+                                        bindings.clone(),
+                                        terminators.clone(),
+                                        plugins.clone(),
+                                        wg.clone(),
+                                        Arc::new(key),
+                                    );
+                                    wg.wait();
+                                },
+                                Err(e) => {
+                                    error!("Provider download failed to {}: {}", &cmd.provider_ref, e)
+                                }
+                            }
                         }
                     }
                 }
@@ -414,12 +476,8 @@ pub(crate) fn spawn_controlplane(
     Ok(())
 }
 
-fn fetch_actor(actor_id: &str) -> Result<crate::actor::Actor> {
-    let vec = crate::inthost::fetch_oci_bytes(actor_id)?;
-
-    crate::actor::Actor::from_slice(&vec)
-}
-
+// This thread handles control plane commands or demands, e.g. "launch actor" and "launch provider"
+// It also responds to provider and actor auctions
 fn spawn_controlplane_handler(
     nc: Arc<RwLock<Option<nats::Connection>>>,
     host_id: String,
@@ -454,12 +512,38 @@ fn spawn_controlplane_handler(
                 } else {
                     cplane_s.send(ControlCommand::TerminateActor(tc)).unwrap();
                 }
+            } else if msg.subject.ends_with(LAUNCH_PROVIDER) && msg.subject.contains(&host_id) {
+                // schedule the provider
+                let lc: LaunchProviderCommand =serde_json::from_slice(&msg.data).unwrap();
+                cplane_s.send(ControlCommand::StartProvider(lc, msg)).unwrap();
+            } else if msg.subject.ends_with(TERMINATE_PROVIDER) && msg.subject.contains(&host_id) {
+                let tc: TerminateProviderCommand = serde_json::from_slice(&msg.data).unwrap();
+                if !image_map.read().unwrap().contains_key(&tc.provider_ref) {
+                    warn!("Received request to terminate non-existent provider. Ignoring.");
+                } else {
+                    cplane_s.send(ControlCommand::TerminateProvider(tc)).unwrap();
+                }
+            } else if msg.subject.ends_with(PROVIDER_AUCTION_REQ) { // ** WARNING ** ORDER OF COMPARISON IS IMPORTANT HERE
+                let req: ProviderAuctionRequest = serde_json::from_slice(&msg.data)?;
+                if image_map.read().unwrap().contains_key(&req.provider_ref) {
+                    trace!("Skipping provider auction response - provider is in local image map");
+                } else {
+                    if !host_satifies_constraints(labels.clone(), &req.constraints) {
+                        trace!("Skipping provider auction response - host does not satisfy constraints.");
+                    } else {
+                        let ar = ProviderAuctionResponse {
+                          provider_ref: req.provider_ref.to_string(),
+                            host_id: host_id.to_string(),
+                        };
+                        info!("Responding to provider schedule auction request");
+                        let _ = msg.respond(serde_json::to_vec(&ar).unwrap());
+                    }
+                }
             } else if msg.subject.ends_with(AUCTION_REQ) {
                 let req: LaunchAuctionRequest = serde_json::from_slice(&msg.data)?;
                 if image_map.read().unwrap().contains_key(&req.actor_id) {
                     trace!("Skipping auction response - actor already running locally.");
                 } else {
-                    // TODO: validate constraint requirements
                     if !host_satifies_constraints(labels.clone(), &req.constraints) {
                         trace!("Skipping auction response - host does not satisfy constraints.");
                     } else {

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -41,6 +41,7 @@ pub(crate) fn new(
     ns: Option<String>,
     cplane_s: Sender<lattice::ControlCommand>,
     authz: Arc<RwLock<Box<dyn crate::authz::Authorizer>>>,
+    image_map: Arc<RwLock<HashMap<String, String>>>,
 ) -> MessageBus {
     lattice::DistributedBus::new(
         host_id,
@@ -52,6 +53,7 @@ pub(crate) fn new(
         ns,
         cplane_s,
         authz,
+        image_map,
     )
 }
 

--- a/src/inthost.rs
+++ b/src/inthost.rs
@@ -10,6 +10,7 @@ use crate::bus::MessageBus;
 use crate::BindingsList;
 use crate::{authz, errors, Actor, Authorizer, NativeCapability, RouteKey};
 use errors::ErrorKind;
+use provider_archive::ProviderArchive;
 use std::str::FromStr;
 use std::{
     collections::HashMap,
@@ -454,9 +455,10 @@ pub(crate) fn fetch_oci_bytes(img: &str) -> Result<Vec<u8>> {
     let mut c = oci_distribution::Client::new(cfg);
 
     let img = oci_distribution::Reference::from_str(img).map_err(|e| {
-        crate::errors::new(crate::errors::ErrorKind::MiscHost(
-            "Could not parse OCI distribution reference".to_string(),
-        ))
+        crate::errors::new(crate::errors::ErrorKind::MiscHost(format!(
+            "Failed to parse OCI distribution reference: {}",
+            e
+        )))
     })?;
     let auth = if let Ok(u) = std::env::var(OCI_VAR_USER) {
         if let Ok(p) = std::env::var(OCI_VAR_PASSWORD) {
@@ -483,6 +485,12 @@ pub(crate) fn fetch_oci_bytes(img: &str) -> Result<Vec<u8>> {
             )))
         }
     }
+}
+
+pub(crate) fn fetch_provider_archive(img: &str) -> Result<ProviderArchive> {
+    let bytes = fetch_oci_bytes(img)?;
+    ProviderArchive::try_load(&bytes)
+        .map_err(|e| format!("Failed to load provider archive: {}", e).into())
 }
 
 fn invocation_from_callback(
@@ -610,8 +618,55 @@ pub(crate) fn detect_core_host_labels() -> HashMap<String, String> {
         CORELABEL_OSFAMILY.to_string(),
         std::env::consts::FAMILY.to_string(),
     );
-    trace!("Intrinsic host labels: {:?}", hm);
+    info!("Detected Intrinsic host labels. hostcore.arch = {}, hostcore.os = {}, hostcore.family = {}",
+          std::env::consts::ARCH,
+          std::env::consts::OS,
+          std::env::consts::FAMILY,
+    );
     hm
+}
+
+pub(crate) fn fetch_actor(actor_id: &str) -> Result<crate::actor::Actor> {
+    let vec = crate::inthost::fetch_oci_bytes(actor_id)?;
+
+    crate::actor::Actor::from_slice(&vec)
+}
+
+pub(crate) fn fetch_provider(
+    provider_ref: &str,
+    binding_name: &str,
+    labels: Arc<RwLock<HashMap<String, String>>>,
+) -> Result<(
+    crate::capability::NativeCapability,
+    Claims<wascap::jwt::CapabilityProvider>,
+)> {
+    use std::fs::File;
+    use std::io::Write;
+
+    let par = crate::inthost::fetch_provider_archive(provider_ref)?;
+    let lock = labels.read().unwrap();
+    let target = format!("{}-{}", lock[CORELABEL_ARCH], lock[CORELABEL_OS]);
+    let v = par.target_bytes(&target);
+    if let Some(v) = v {
+        let path = std::env::temp_dir();
+        let path = path.join(target);
+        {
+            let mut tf = File::create(&path)?;
+            tf.write_all(&v)?;
+        }
+        let nc = NativeCapability::from_file(path, Some(binding_name.to_string()))?;
+        if let Some(c) = par.claims() {
+            Ok((nc, c))
+        } else {
+            Err(format!(
+                "No embedded claims found in provider archive for {}",
+                provider_ref
+            )
+            .into())
+        }
+    } else {
+        Err(format!("No binary found in provider archive for {}", target).into())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The first part of this pull request adds support for OCI-registry-housed actors.

1. When a request to schedule an actor comes from the lattice, this request _must_ be an OCI reference (e.g. `myregistry.azurecr.io/someactor:v1`
    1. This means the existing lattice client CLI is outdated as of this PR.
2. When reading actors out of a manifest file, if the string from the file exists on disk, the host will load it from disk as before. If not, the host will assume the string is an OCI reference and try and resolve it and fetch the image.
3. You can now choose whether you add an actor from an instance or from an OCI reference via `add_actor_from_registry`
4. All pre-existing manifests that use file-based actors should work with no interruption.

The same type of support for capability providers will get added to this PR as we gain the ability to reliably generate PAR files from a CLI (`wcc`?)